### PR TITLE
ISSUE-1 md5 hashing of directory

### DIFF
--- a/ComposerMergePlugin.php
+++ b/ComposerMergePlugin.php
@@ -305,7 +305,7 @@ class ComposerMergePlugin implements PluginInterface, EventSubscriberInterface {
 			// Create directories at the destination and recursively copy their contents:
 			if (!is_dir($dst)) {
 				if (@mkdir($dst)) {
-					$this->mergeLog[] = array(self::TYPE_DIRECTORY, $dst, $src, md5_file($dst));
+					$this->mergeLog[] = array(self::TYPE_DIRECTORY, $dst, $src, @md5_file($dst));
 				} else {
 					$this->io->writeError('<warning>Can\'t copy directory ' . $src . ' to ' . $dst . '</warning>');
 				}


### PR DESCRIPTION
Added error control operator to suppress warning messages. The situation is problably caused by using composer with xdebug enabled.
