### PR TITLE
Fixed compatibility issue with newer Composer versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IDE files
+.idea/

--- a/ComposerMergePlugin.php
+++ b/ComposerMergePlugin.php
@@ -33,7 +33,7 @@ use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
 use Composer\Plugin\PluginInterface;
-use Composer\Script\CommandEvent;
+use Composer\Script\Event;
 
 class ComposerMergePlugin implements PluginInterface, EventSubscriberInterface {
 	const MERGE_LOG_FILENAME = 'composer-merge-log.json';
@@ -60,15 +60,15 @@ class ComposerMergePlugin implements PluginInterface, EventSubscriberInterface {
 		return array('post-install-cmd' => 'onPostInstallCmd', 'post-update-cmd' => 'onPostUpdateCmd');
 	}
 	
-	public function onPostInstallCmd(CommandEvent $event) {
+	public function onPostInstallCmd(Event $event) {
 		$this->run($event);
 	}
 	
-	public function onPostUpdateCmd(CommandEvent $event) {
+	public function onPostUpdateCmd(Event $event) {
 		$this->run($event);
 	}
 	
-	protected function run(CommandEvent $event) {
+	protected function run(Event $event) {
 		$this->unmerge();
 		$this->merge($event->isDevMode());
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,7 @@
 {
     "name": "viison/composer-merge-plugin",
+    "version": "1.0.0",
+    "description": "Composer Merge Plugin for directory merging after install/update.",
     "type": "composer-plugin",
     "autoload": {
         "psr-4": {"Viison\\Composer\\": ""}


### PR DESCRIPTION
Fixed deprecated class use from CommandEvent to Event.
In Composer v1.5.0, this issues shows a deprecation notice, but eventually it could become an error.